### PR TITLE
Use the current environment

### DIFF
--- a/Command/ClearRoutingCacheCommand.php
+++ b/Command/ClearRoutingCacheCommand.php
@@ -19,16 +19,17 @@ class ClearRoutingCacheCommand extends Command
     protected function configure()
     {
         $this->setName('cache:clear:routing')
-            ->setDescription('Clear Routing Cache')
-            ->addArgument('env', InputArgument::OPTIONAL, '[dev,prod,test]');
+            ->setDescription('Clear Routing Cache');
     }
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $output->writeln('');
-        $helper = $this->getApplication()->getKernel()->getContainer()->get('eschmar_doctrine_routing.helper');
+        $kernel = $this->getApplication()->getKernel();
+        $helper = $kernel->getContainer()->get('eschmar_doctrine_routing.helper');
+        $env = $kernel->getEnvironment();
 
-        if (!$helper->clear($input->getArgument('env'))) {
+        if (!$helper->clear($env)) {
             foreach ($helper->error_stack as $error) {
                 $output->writeln('<error>'.$error.'</error>');
             }


### PR DESCRIPTION
All commands are run within a specific environment so we can simply obtain that from the kernel.

To clear a different cache you would simply set the environment with the `-e` flag as usual